### PR TITLE
Make it work again with files with spaces in filename

### DIFF
--- a/perl/kaktree.pl
+++ b/perl/kaktree.pl
@@ -35,7 +35,6 @@ sub build_tree {
     my $real_path = abs_path(escape_path($path));
 
     $real_path =~ s/\s+$//;
-    $real_path = escape_path($real_path);
 
     chomp(my @input = `ls -1LFb 2>&- $hidden_arg $real_path`);
 


### PR DESCRIPTION
**Breaking change**: no

**Description**:
The previous version did no longer work with files with spaces in the filename. I found that this was caused by double escaping of the space. So, "space directory" became "space\\ directory". Now I removed the second escape, so it now correctly becomes "space\ directory" and works again.
